### PR TITLE
Fixed error where Regio would have a null Construccio

### DIFF
--- a/src/Construccio.java
+++ b/src/Construccio.java
@@ -32,6 +32,8 @@ public class Construccio {
 
     public void fusionar(Construccio c){
         _regions.addAll(c.get_regions());
+        for(Regio r : c.get_regions()) r.set_pertany(this);
+        
         for (Map.Entry pair : c.get_seguidors().entrySet()) {
             Jugador clau = (Jugador) pair.getKey();
             if(_seguidors.containsKey(clau)){

--- a/src/Tauler.java
+++ b/src/Tauler.java
@@ -53,6 +53,13 @@ public class Tauler {
         peça.set_adjacents(adjacents);
         System.out.println("arriba");
         
+        //Comprovació de peça amb Monestir
+        if(peça.centre()=='M'){
+            Regio m = peça.getRegio(-1);
+            Construccio c = new Monestir(m);
+            m.set_pertany(c);
+        }
+        
         for(int i=0;i<4;i++){
             Regio r = peça.getRegio(i);
             System.out.println(i+": "+r.hashCode());


### PR DESCRIPTION
Fixed error where Regio would have a null Construccio. It was caused by:
- Not creating a Monestir when a Peça was added with monestir in the center.
- Not updating Regions after a fusion was done and one of the Construccions was deleted.